### PR TITLE
Changed cursor on scrollbar hover/drag from pointer to default

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -72,6 +72,7 @@ ul {
 
 .ng-scrollbar-thumb {
   background-color: #007bff;
+  cursor: default;
 }
 
 .sample {


### PR DESCRIPTION
Default cursor behaviour on scrollbar hover/drag should not be `cursor: pointer`, but just the default cursor.