### PR TITLE
Avoid `undefined` `MutationObserver` exception on Node

### DIFF
--- a/projects/ngx-scrollbar/src/lib/scrollbar.component.ts
+++ b/projects/ngx-scrollbar/src/lib/scrollbar.component.ts
@@ -100,7 +100,7 @@ export class ScrollbarComponent implements AfterViewInit, OnDestroy {
         this._thumbYSub$ = this.startThumbYWorker();
       }
 
-      if (this.autoUpdate) {
+      if (this.autoUpdate && typeof MutationObserver !== 'undefined') {
         /** Observe content changes */
         this._observer = new MutationObserver(() => this.update());
         this._observer.observe(this.view, { subtree: true, childList: true });


### PR DESCRIPTION
When `ngx-scrollbar` package is used on the server-side, it throws an exception, since `MutationObserver` is not defined on the server. Ideally it is not polyfilled on a Node environment but this package makes use of `MutationObserver` when it is available.

This approach is commonly used in other packagages, example: https://github.com/zefoy/ngx-swiper-wrapper/blob/62d3ed3ade8909ec990ff9caee6c5ca710ae3a7b/src/lib/swiper.component.ts#L115