### PR TITLE
Avoid enable execution if disabled and fix server-side rendering crash

### DIFF
--- a/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar.ts
+++ b/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar.ts
@@ -145,7 +145,7 @@ export class NgScrollbar implements AfterViewInit, OnDestroy {
       this._nativeScrollbarSize = `${this.view.offsetWidth - this.view.clientWidth + 1}px`;
       this.updateState();
 
-      if (this.autoUpdate) {
+      if (this.autoUpdate && typeof MutationObserver !== 'undefined') {
         // Observe content changes
         this._observer = new MutationObserver(() => this.update());
         this._observer.observe(this.view, {subtree: true, childList: true, characterData: true});

--- a/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar.ts
+++ b/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar.ts
@@ -101,13 +101,13 @@ export class NgScrollbar implements AfterViewInit, OnDestroy {
   ngAfterViewInit() {
     this.view = this.scrollable.getElementRef().nativeElement;
 
-    if (this.disableOnBreakpoints) {
+    if (this.disableOnBreakpoints && !this.disabled) {
       // Enable/Disable custom scrollbar on breakpoints (Used to disable scrollbars on mobile phones)
       this._breakpointSub$ = this.breakpointObserver.observe(this.disableOnBreakpoints).pipe(
         // filter(() => this.viewInitialized),
         tap((result: BreakpointState) => result.matches ? this.disable() : this.enable())
       ).subscribe();
-    } else {
+    } else if (!this.disabled) {
       this.enable();
     }
 


### PR DESCRIPTION
When disableOnBreakpoints was not matching results, enable() was executed, thus disabled param was ignored. 

MutationObserver is not available when rendering server side, thus it was crashing when using it in server side. 