### PR TITLE
Fix AnimationFrameScheduler is not defined in server side

### DIFF
--- a/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar-horizontal.ts
+++ b/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar-horizontal.ts
@@ -1,5 +1,5 @@
-import { Component, Inject, NgZone, ChangeDetectionStrategy, forwardRef } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
+import { Component, Inject, NgZone, ChangeDetectionStrategy, forwardRef, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { fromEvent, Observable, animationFrameScheduler } from 'rxjs';
 import { mergeMap, pluck, takeUntil, tap } from 'rxjs/operators';
 import { NgScrollbar } from './ng-scrollbar';
@@ -29,6 +29,7 @@ export class NgScrollbarHorizontal extends NgScrollbarThumb {
   }
 
   constructor(@Inject(DOCUMENT) protected _document: any,
+              @Inject(PLATFORM_ID) private _platform: Object,
               @Inject(forwardRef(() => NgScrollbar)) protected _parent: NgScrollbar,
               protected _zone: NgZone) {
     super(_parent, _zone);
@@ -54,14 +55,16 @@ export class NgScrollbarHorizontal extends NgScrollbarThumb {
     this._thumbSize = this.thumb.nativeElement.clientWidth;
     this._trackMax = this.bar.nativeElement.clientWidth - this._thumbSize;
     this._currPos = this._view.scrollLeft * this._trackMax / this._scrollMax;
-    this._zone.run(() =>
-      animationFrameScheduler.schedule(() =>
-        this.updateState({
-          transform: `translate3d(${this._currPos}px, 0, 0)`,
-          width: `${this.thumbSize}px`
-        })
-      )
-    );
+    this._zone.run(() => {
+      if (isPlatformBrowser(this._platform)) {
+        animationFrameScheduler.schedule(() =>
+          this.updateState({
+            transform: `translate3d(${this._currPos}px, 0, 0)`,
+            width: `${this.thumbSize}px`
+          })
+        )
+      }
+    });
   }
 
   /**

--- a/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar-horizontal.ts
+++ b/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar-horizontal.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, NgZone, ChangeDetectionStrategy, forwardRef, PLATFORM_ID } from '@angular/core';
-import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { DOCUMENT } from '@angular/common';
 import { fromEvent, Observable, animationFrameScheduler } from 'rxjs';
 import { mergeMap, pluck, takeUntil, tap } from 'rxjs/operators';
 import { NgScrollbar } from './ng-scrollbar';
@@ -29,10 +29,10 @@ export class NgScrollbarHorizontal extends NgScrollbarThumb {
   }
 
   constructor(@Inject(DOCUMENT) protected _document: any,
-              @Inject(PLATFORM_ID) private _platform: Object,
               @Inject(forwardRef(() => NgScrollbar)) protected _parent: NgScrollbar,
+              @Inject(PLATFORM_ID) _platform: Object,
               protected _zone: NgZone) {
-    super(_parent, _zone);
+    super(_parent, _platform, _zone);
   }
 
   /**
@@ -56,14 +56,12 @@ export class NgScrollbarHorizontal extends NgScrollbarThumb {
     this._trackMax = this.bar.nativeElement.clientWidth - this._thumbSize;
     this._currPos = this._view.scrollLeft * this._trackMax / this._scrollMax;
     this._zone.run(() => {
-      if (isPlatformBrowser(this._platform)) {
-        animationFrameScheduler.schedule(() =>
-          this.updateState({
-            transform: `translate3d(${this._currPos}px, 0, 0)`,
-            width: `${this.thumbSize}px`
-          })
-        )
-      }
+      animationFrameScheduler.schedule(() =>
+        this.updateState({
+          transform: `translate3d(${this._currPos}px, 0, 0)`,
+          width: `${this.thumbSize}px`
+        })
+      );
     });
   }
 

--- a/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar-vertical.ts
+++ b/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar-vertical.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, NgZone, ChangeDetectionStrategy, forwardRef, PLATFORM_ID } from '@angular/core';
-import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { DOCUMENT } from '@angular/common';
 import { fromEvent, Observable, animationFrameScheduler } from 'rxjs';
 import { mergeMap, pluck, takeUntil, tap } from 'rxjs/operators';
 import { NgScrollbar } from './ng-scrollbar';
@@ -29,10 +29,10 @@ export class NgScrollbarVertical extends NgScrollbarThumb {
   }
 
   constructor(@Inject(DOCUMENT) protected _document: any,
-              @Inject(PLATFORM_ID) private _platform: Object,
               @Inject(forwardRef(() => NgScrollbar)) protected _parent: NgScrollbar,
+              @Inject(PLATFORM_ID) _platform: Object,
               protected _zone: NgZone) {
-    super(_parent, _zone);
+    super(_parent, _platform, _zone);
   }
 
   /**
@@ -56,14 +56,12 @@ export class NgScrollbarVertical extends NgScrollbarThumb {
     this._trackMax = this.bar.nativeElement.clientHeight - this._thumbSize;
     this._currPos = this._view.scrollTop * this._trackMax / this._scrollMax;
     this._zone.run(() => {
-      if (isPlatformBrowser(this._platform)) {
-        animationFrameScheduler.schedule(() =>
-          this.updateState({
-            transform: `translate3d(0, ${this._currPos}px, 0)`,
-            height: `${this.thumbSize}px`
-          })
-        )
-      }
+      animationFrameScheduler.schedule(() =>
+        this.updateState({
+          transform: `translate3d(0, ${this._currPos}px, 0)`,
+          height: `${this.thumbSize}px`
+        })
+      );
     });
   }
 

--- a/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar-vertical.ts
+++ b/projects/ngx-scrollbar/src/scrollbar/ng-scrollbar-vertical.ts
@@ -1,5 +1,5 @@
-import { Component, Inject, NgZone, ChangeDetectionStrategy, forwardRef } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
+import { Component, Inject, NgZone, ChangeDetectionStrategy, forwardRef, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { fromEvent, Observable, animationFrameScheduler } from 'rxjs';
 import { mergeMap, pluck, takeUntil, tap } from 'rxjs/operators';
 import { NgScrollbar } from './ng-scrollbar';
@@ -29,6 +29,7 @@ export class NgScrollbarVertical extends NgScrollbarThumb {
   }
 
   constructor(@Inject(DOCUMENT) protected _document: any,
+              @Inject(PLATFORM_ID) private _platform: Object,
               @Inject(forwardRef(() => NgScrollbar)) protected _parent: NgScrollbar,
               protected _zone: NgZone) {
     super(_parent, _zone);
@@ -54,14 +55,16 @@ export class NgScrollbarVertical extends NgScrollbarThumb {
     this._thumbSize = this.thumb.nativeElement.clientHeight;
     this._trackMax = this.bar.nativeElement.clientHeight - this._thumbSize;
     this._currPos = this._view.scrollTop * this._trackMax / this._scrollMax;
-    this._zone.run(() =>
-      animationFrameScheduler.schedule(() =>
-        this.updateState({
-          transform: `translate3d(0, ${this._currPos}px, 0)`,
-          height: `${this.thumbSize}px`
-        })
-      )
-    );
+    this._zone.run(() => {
+      if (isPlatformBrowser(this._platform)) {
+        animationFrameScheduler.schedule(() =>
+          this.updateState({
+            transform: `translate3d(0, ${this._currPos}px, 0)`,
+            height: `${this.thumbSize}px`
+          })
+        )
+      }
+    });
   }
 
   /**

--- a/projects/ngx-scrollbar/src/smooth-scroll/smooth-scroll.ts
+++ b/projects/ngx-scrollbar/src/smooth-scroll/smooth-scroll.ts
@@ -1,4 +1,5 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { supportsScrollBehavior } from '@angular/cdk/platform';
 import { Observable, from, of, animationFrameScheduler } from 'rxjs';
 
@@ -28,7 +29,9 @@ export class SmoothScroll {
 
   private readonly view: HTMLElement;
 
-  constructor(el: ElementRef) {
+  constructor(
+    @Inject(PLATFORM_ID) private _platform: Object,
+    el: ElementRef) {
     this.view = el.nativeElement;
   }
 
@@ -119,7 +122,9 @@ export function smoothScroll(options: SmoothScrollOptions): Promise<void> {
       options.scrollFunc(valX, valY);
       // do the animation unless its over
       if (currentTime < options.duration) {
-        animationFrameScheduler.schedule(animateScroll);
+        if (isPlatformBrowser(this._platform)) {
+          animationFrameScheduler.schedule(animateScroll);
+        }
       } else {
         resolve();
       }

--- a/projects/ngx-scrollbar/src/smooth-scroll/smooth-scroll.ts
+++ b/projects/ngx-scrollbar/src/smooth-scroll/smooth-scroll.ts
@@ -29,9 +29,8 @@ export class SmoothScroll {
 
   private readonly view: HTMLElement;
 
-  constructor(
-    @Inject(PLATFORM_ID) private _platform: Object,
-    el: ElementRef) {
+  constructor(@Inject(PLATFORM_ID) private _platform: Object,
+              el: ElementRef) {
     this.view = el.nativeElement;
   }
 
@@ -122,14 +121,16 @@ export function smoothScroll(options: SmoothScrollOptions): Promise<void> {
       options.scrollFunc(valX, valY);
       // do the animation unless its over
       if (currentTime < options.duration) {
-        if (isPlatformBrowser(this._platform)) {
-          animationFrameScheduler.schedule(animateScroll);
-        }
+        animationFrameScheduler.schedule(animateScroll);
       } else {
         resolve();
       }
     };
-    animateScroll();
+
+    // Avoid SSR error
+    if (isPlatformBrowser(this._platform)) {
+      animateScroll();
+    }
   });
 }
 


### PR DESCRIPTION
I've noticed an error when using server side rendering. AnimationFrameScheduler is not defied, so when schedule method is invoked, it raises an exception.

This pull request controls the usages of animationFrameScheduler and makes sure that it is only used in browser platforms. 