### PR TITLE
Refactor smooth scroll

### DIFF
--- a/projects/ngx-scrollbar/smooth-scroll/src/public_api.ts
+++ b/projects/ngx-scrollbar/smooth-scroll/src/public_api.ts
@@ -1,3 +1,4 @@
 export * from './smooth-scroll-manager';
 export * from './smooth-scroll';
 export * from './smooth-scroll.module';
+export * from './smooth-scroll.model';

--- a/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll-manager.ts
+++ b/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll-manager.ts
@@ -42,7 +42,7 @@ export class SmoothScrollManager {
 
   constructor(private _zone: NgZone,
               private _dir: Directionality,
-              @Inject(DOCUMENT) private _document: Document,
+              @Inject(DOCUMENT) private _document: any,
               @Inject(PLATFORM_ID) private _platform: object,
               @Optional() @Inject(SMOOTH_SCROLL_OPTIONS) customDefaultOptions: SmoothScrollToOptions) {
     this._defaultOptions = {

--- a/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll-manager.ts
+++ b/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll-manager.ts
@@ -1,163 +1,261 @@
-import { ElementRef, Inject, Injectable, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { ElementRef, Inject, Injectable, PLATFORM_ID, Optional, NgZone } from '@angular/core';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { coerceElement } from '@angular/cdk/coercion';
-import { fromEvent, merge, timer } from 'rxjs';
-import { map, take, takeUntil, takeWhile, tap } from 'rxjs/operators';
+import { Directionality } from '@angular/cdk/bidi';
+import { getRtlScrollAxisType, RtlScrollAxisType } from '@angular/cdk/platform';
+import { _Bottom, _Left, _Right, _Top, _Without } from '@angular/cdk/scrolling';
+import { fromEvent, merge, of, Observable, Subject } from 'rxjs';
+import { expand, finalize, take, takeUntil, takeWhile } from 'rxjs/operators';
+import {
+  easeInOutQuad,
+  SMOOTH_SCROLL_OPTIONS,
+  SmoothScrollElement,
+  SmoothScrollOptions,
+  SmoothScrollStep,
+  SmoothScrollToOptions
+} from './smooth-scroll.model';
 
-export type SmoothScrollEaseFunc = (t: number, s: number, c: number, d: number) => number;
-
-export interface SmoothScrollToOptions {
-  top?: number;
-  left?: number;
-  duration?: number;
-  easeFunc?: SmoothScrollEaseFunc;
-}
-
-interface ScrollToState {
-  left: number;
-  top: number;
-  elapsedTime: number;
-}
-
-// @dynamic
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable({ providedIn: 'root' })
 export class SmoothScrollManager {
 
-  constructor(@Inject(PLATFORM_ID) private platform: object) {
+  // Default options
+  private _defaultOptions: SmoothScrollToOptions;
+
+  // Keeps track of the ongoing SmoothScroll functions so they can be handled in case of duplication.
+  // Each scrolled element gets a destroyer stream which gets deleted immediately after it completes.
+  // Purpose: If user called a scroll function again on the same element before the scrolls completes,
+  // it cancels the ongoing scroll and starts a new one
+  private _onGoingScrolls = new Map<HTMLElement, Subject<void>>();
+
+  private get _w(): any {
+    return this._document.defaultView;
   }
 
-  scrollTo(viewElementOrRef: HTMLElement | ElementRef<HTMLElement>, options: SmoothScrollToOptions): Promise<void> {
-    const view = coerceElement<HTMLElement>(viewElementOrRef);
-    return new Promise<void>((resolve => {
-      // Avoid SSR error
-      if (isPlatformBrowser(this.platform)) {
-        const easeFunc = options.easeFunc || easeInOutQuad;
-        const startTime = Date.now();
-        // Stream that emits once user scroll using mousewheel or touchmove events to cancel any ongoing smooth scroll
-        const userInterrupt = merge(
-          fromEvent(view, 'mousewheel', { passive: true, capture: true }),
-          fromEvent(view, 'touchmove', { passive: true, capture: true })
-        ).pipe(take(1));
-        /**
-         * TODO: Add a feature to automatically set a proper duration based on scroll distance relative to the viewport size
-         * e.g. if scroll distance is twice as big as the viewport size, duration should be around ~800ms
-         * and but if scroll distance is tiny then use ~300ms
-         *
-         * const getDuration = (distance: number, viewSize: number, scrollSize: number) => {
-         *  if (distance > viewSize) {
-         *    console.log(`[Should slow down] distance > viewSize`, distance, viewSize, scrollSize);
-         *   return (distance % 50) * 100;
-         *  } else {
-         *    console.log(`[Should be fast] distance <= viewSize`, distance, viewSize, scrollSize);
-         *    return (distance % 50) * 20;
-         *  }
-         * };
-         * const durationX = (typeof options.left !== 'undefined') ? getDuration(~~Math.abs(options.left - view.scrollLeft), view.clientWidth, view.scrollWidth) : 0;
-         * const durationY = (typeof options.top !== 'undefined') ? getDuration(~~Math.abs(options.top - view.scrollTop), view.clientHeight, view.scrollHeight) : 0;
-         * const duration = Math.max(durationX, durationY);
-         * console.log(`duration: ${ duration }`);
-         */
+  /**
+   * Timing method
+   */
+  private get _now() {
+    return this._w.performance && this._w.performance.now
+      ? this._w.performance.now.bind(this._w.performance)
+      : Date.now;
+  }
 
-        const ease = (elapsedTime: number, point: number, offset: number): number => {
-          const delta = point - offset;
-          return easeFunc(elapsedTime, offset, delta, options.duration);
-        };
+  constructor(private _zone: NgZone,
+              private _dir: Directionality,
+              @Inject(DOCUMENT) private _document: Document,
+              @Inject(PLATFORM_ID) private _platform: object,
+              @Optional() @Inject(SMOOTH_SCROLL_OPTIONS) customDefaultOptions: SmoothScrollToOptions) {
+    this._defaultOptions = {
+      duration: 468,
+      easeFunc: easeInOutQuad,
+      ...customDefaultOptions,
+    };
+  }
 
-        const scrollLeft = view.scrollLeft;
-        const scrollTop = view.scrollTop;
-        timer(0, 20).pipe(
-          map(() => {
-            const elapsedTime = Date.now() - startTime;
-            return {
-              left: (typeof options.left !== 'undefined') ? ease(elapsedTime, options.left, scrollLeft) : scrollLeft,
-              top: (typeof options.top !== 'undefined') ? ease(elapsedTime, options.top, scrollTop) : scrollTop,
-              elapsedTime
-            };
-          }),
-          tap((target: ScrollToState) => {
-            view.scrollTop = target.top;
-            view.scrollLeft = target.left;
-          }),
-          takeWhile((target: ScrollToState) => {
-            const finished = !(target.elapsedTime < options.duration);
-            if (finished) {
-              resolve();
-            }
-            return !finished;
-          }),
-          takeUntil(userInterrupt)
-        ).subscribe();
+  /**
+   * changes scroll position inside an element
+   */
+  private _scrollElement(el: HTMLElement, x: number, y: number): void {
+    el.scrollLeft = x;
+    el.scrollTop = y;
+  }
+
+  /**
+   * Handles a given parameter of type HTMLElement, ElementRef or selector
+   */
+  private _getElement(el: HTMLElement | ElementRef | string, parent?: HTMLElement): HTMLElement {
+    if (typeof el === 'string') {
+      return (parent || this._document).querySelector<HTMLElement>(el);
+    }
+    return coerceElement<HTMLElement>(el);
+  }
+
+  /**
+   * Initializes a destroyer stream, re-initializes it if the element is already being scrolled
+   */
+  private _initSmoothScroll(el: HTMLElement): Subject<void> {
+    if (this._onGoingScrolls.has(el)) {
+      this._onGoingScrolls.get(el).next();
+    }
+    return this._onGoingScrolls.set(el, new Subject<void>()).get(el);
+  }
+
+  /**
+   * Checks if smooth scroll has reached, cleans up the smooth scroll stream and resolves its promise
+   */
+  private _isFinished(context: SmoothScrollStep, destroyed: Subject<void>, resolve: () => void): boolean {
+    if (context.currentX !== context.x || context.currentY !== context.y) {
+      return true;
+    }
+    destroyed.next();
+    resolve();
+    return false;
+  }
+
+  /**
+   * Terminates an ongoing smooth scroll
+   */
+  private _interrupted(el: HTMLElement, destroyed: Subject<void>): Observable<any> {
+    return merge(
+      fromEvent(el, 'wheel', { passive: true, capture: true }),
+      fromEvent(el, 'touchmove', { passive: true, capture: true }),
+      destroyed
+    ).pipe(take(1));
+  }
+
+  /**
+   * Deletes the destroyer function, runs if the smooth scroll has finished or interrupted
+   */
+  private _destroy(el: HTMLElement, destroyed: Subject<void>): void {
+    destroyed.complete();
+    this._onGoingScrolls.delete(el);
+  }
+
+  /**
+   * A function called recursively that, given a context, steps through scrolling
+   */
+  private _step(context: SmoothScrollStep): Observable<SmoothScrollStep> {
+    return new Observable(observer => {
+      const elapsed = this._now() - context.startTime;
+
+      // avoid elapsed times higher than the duration
+      if (elapsed >= context.duration) {
+        context.currentX = context.x;
+        context.currentY = context.y;
+      } else {
+        context.currentX = context.easeFunc(elapsed, context.startX, context.x - context.startX, context.duration);
+        context.currentY = context.easeFunc(elapsed, context.startY, context.y - context.startY, context.duration);
       }
-    }));
+
+      this._scrollElement(context.scrollable, context.currentX, context.currentY);
+      // Proceed to the step
+      requestAnimationFrame(() => observer.next(context));
+    });
   }
 
-  /** Scroll to element by reference */
-  scrollToElement(viewElementOrRef: HTMLElement | ElementRef<HTMLElement>,
-                  targetElementOrRef: HTMLElement | ElementRef<HTMLElement>,
-                  offset = 0, duration?: number,
-                  easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    const target = coerceElement<HTMLElement>(targetElementOrRef);
-    return target ? this.scrollTo(viewElementOrRef, {
-      left: target.offsetLeft,
-      top: target.offsetTop - offset,
+  private _applyScrollToOptions(el: HTMLElement, options: SmoothScrollToOptions): Promise<void> {
+    if (!options.duration) {
+      this._scrollElement(el, options.left, options.top);
+      return Promise.resolve();
+    }
+
+    // Initialize a destroyer stream, reinitialize it if the element is already being scrolled
+    const destroyed: Subject<void> = this._initSmoothScroll(el);
+
+    const context: SmoothScrollStep = {
+      scrollable: el,
+      startTime: this._now(),
+      startX: el.scrollLeft,
+      startY: el.scrollTop,
+      x: options.left == null ? el.scrollLeft : ~~options.left,
+      y: options.top == null ? el.scrollTop : ~~options.top,
+      duration: options.duration || this._defaultOptions.duration,
+      easeFunc: options.easeFunc || this._defaultOptions.easeFunc
+    };
+
+    return new Promise(resolve => {
+      // Scroll each step recursively
+      of(null).pipe(
+        expand(() => this._step(context).pipe(
+          takeWhile((currContext: SmoothScrollStep) => this._isFinished(currContext, destroyed, resolve))
+        )),
+        takeUntil(this._interrupted(el, destroyed)),
+        finalize(() => this._destroy(el, destroyed))
+      ).subscribe();
+    });
+  }
+
+
+  /**
+   * Scrolls to the specified offsets. This is a normalized version of the browser's native scrollTo
+   * method, since browsers are not consistent about what scrollLeft means in RTL. For this method
+   * left and right always refer to the left and right side of the scrolling container irrespective
+   * of the layout direction. start and end refer to left and right in an LTR context and vice-versa
+   * in an RTL context.
+   * @param scrollable element
+   * @param options specified the offsets to scroll to.
+   */
+  scrollTo(scrollable: SmoothScrollElement, options: SmoothScrollToOptions): Promise<void> {
+    if (isPlatformBrowser(this._platform)) {
+      const el = this._getElement(scrollable);
+      const isRtl = getComputedStyle(el).direction === 'rtl';
+      const rtlScrollAxisType = getRtlScrollAxisType();
+
+      // Rewrite start & end offsets as right or left offsets.
+      options.left = options.left == null ? (isRtl ? options.end : options.start) : options.left;
+      options.right = options.right == null ? (isRtl ? options.start : options.end) : options.right;
+
+      // Rewrite the bottom offset as a top offset.
+      if (options.bottom != null) {
+        (options as _Without<_Bottom> & _Top).top = el.scrollHeight - el.clientHeight - options.bottom;
+      }
+
+      // Rewrite the right offset as a left offset.
+      if (isRtl && rtlScrollAxisType !== RtlScrollAxisType.NORMAL) {
+        if (options.left != null) {
+          (options as _Without<_Left> & _Right).right = el.scrollWidth - el.clientWidth - options.left;
+        }
+
+        if (rtlScrollAxisType === RtlScrollAxisType.INVERTED) {
+          options.left = options.right;
+        } else if (rtlScrollAxisType === RtlScrollAxisType.NEGATED) {
+          options.left = options.right ? -options.right : options.right;
+        }
+      } else {
+        if (options.right != null) {
+          (options as _Without<_Right> & _Left).left = el.scrollWidth - el.clientWidth - options.right;
+        }
+      }
+      return this._applyScrollToOptions(el, options);
+    }
+  }
+
+  /**
+   * Scroll to element by reference or selector
+   */
+  scrollToElement(scrollable: SmoothScrollElement, target: SmoothScrollElement, options: SmoothScrollOptions & _Top & _Left): Promise<void> {
+    const scrollableEl = this._getElement(scrollable);
+    const targetEl = this._getElement(target, scrollableEl);
+    const duration = options.duration;
+    const easeFunc = options.easeFunc;
+    return targetEl ? this.scrollTo(scrollableEl, {
+      left: targetEl.offsetLeft + (options.left || 0),
+      top: targetEl.offsetTop + (options.top || 0),
       duration,
       easeFunc
-    }) : Promise.resolve();
+    }) : new Promise(null);
   }
 
-  /** Scroll to element by selector */
-  scrollToSelector(viewElementOrRef: HTMLElement | ElementRef<HTMLElement>,
-                   selector: string,
-                   offset = 0,
-                   duration?: number,
-                   easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    const view = coerceElement<HTMLElement>(viewElementOrRef);
-    return this.scrollToElement(view, view.querySelector<HTMLElement>(selector), offset, duration, easeFunc);
+  /**
+   * Scroll to top
+   * @deprecated since version 6.0, use scrollTo({ top: 0}) instead
+   */
+  scrollToTop(scrollable: SmoothScrollElement, options?: SmoothScrollOptions): Promise<void> {
+    return this.scrollTo(scrollable, { top: 0, ...options });
   }
 
-  /** Scroll to top */
-  scrollToTop(viewElementOrRef: HTMLElement | ElementRef<HTMLElement>,
-              offset = 0,
-              duration?: number,
-              easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.scrollTo(viewElementOrRef, { top: 0 - offset, duration, easeFunc });
+  /**
+   * Scroll to bottom
+   * @deprecated since version 6.0, use scrollTo({ bottom: 0}) instead
+   */
+  scrollToBottom(scrollable: SmoothScrollElement, options?: SmoothScrollOptions): Promise<void> {
+    return this.scrollTo(scrollable, { bottom: 0, ...options });
   }
 
-  /** Scroll to bottom */
-  scrollToBottom(viewElementOrRef: HTMLElement | ElementRef<HTMLElement>,
-                 offset = 0,
-                 duration?: number,
-                 easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    const view = coerceElement<HTMLElement>(viewElementOrRef);
-    return this.scrollTo(view, { top: view.scrollHeight - view.clientHeight, duration, easeFunc });
+  /**
+   *  Scroll to left
+   * @deprecated since version 6.0, use scrollTo({ left: 0}) instead
+   */
+  scrollToLeft(scrollable: SmoothScrollElement, options?: SmoothScrollOptions): Promise<void> {
+    return this.scrollTo(scrollable, { left: 0, ...options });
   }
 
-  /** Scroll to left */
-  scrollToLeft(viewElementOrRef: HTMLElement | ElementRef<HTMLElement>,
-               offset = 0,
-               duration?: number,
-               easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.scrollTo(viewElementOrRef, { left: 0 - offset, duration, easeFunc });
-  }
-
-  /** Scroll to right */
-  scrollToRight(viewElementOrRef: HTMLElement | ElementRef<HTMLElement>,
-                offset = 0,
-                duration?: number,
-                easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    const view = coerceElement<HTMLElement>(viewElementOrRef);
-    return this.scrollTo(view, { left: view.scrollWidth - offset, duration, easeFunc });
+  /**
+   * Scroll to right
+   * @deprecated since version 6.0, use scrollTo({ right: 0}) instead
+   */
+  scrollToRight(scrollable: SmoothScrollElement, options?: SmoothScrollOptions): Promise<void> {
+    return this.scrollTo(scrollable, { right: 0, ...options });
   }
 }
 
-// easing functions http://goo.gl/5HLl8
-export function easeInOutQuad(t: number, b: number, c: number, d: number) {
-  t /= d / 2;
-  if (t < 1) {
-    return (c / 2) * t * t + b;
-  }
-  t--;
-  return (-c / 2) * (t * (t - 2) - 1) + b;
-}

--- a/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll-manager.ts
+++ b/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll-manager.ts
@@ -15,7 +15,10 @@ import {
   SmoothScrollToOptions
 } from './smooth-scroll.model';
 
-@Injectable({ providedIn: 'root' })
+// @dynamic
+@Injectable({
+  providedIn: 'root'
+})
 export class SmoothScrollManager {
 
   // Default options
@@ -65,7 +68,7 @@ export class SmoothScrollManager {
    */
   private _getElement(el: HTMLElement | ElementRef | string, parent?: HTMLElement): HTMLElement {
     if (typeof el === 'string') {
-      return (parent || this._document).querySelector<HTMLElement>(el);
+      return (parent || this._document).querySelector(el);
     }
     return coerceElement<HTMLElement>(el);
   }

--- a/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll.model.ts
+++ b/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll.model.ts
@@ -1,0 +1,38 @@
+import { ElementRef, InjectionToken } from '@angular/core';
+import { _XAxis, _YAxis } from '@angular/cdk/scrolling';
+
+export const SMOOTH_SCROLL_OPTIONS = new InjectionToken<SmoothScrollOptions>('SMOOTH_SCROLL_OPTIONS');
+
+export type SmoothScrollElement = HTMLElement | ElementRef<HTMLElement> | string;
+
+export type SmoothScrollToOptions = _XAxis & _YAxis & SmoothScrollOptions;
+
+export type SmoothScrollEaseFunc = (t: number, s: number, c: number, d: number) => number;
+
+export interface SmoothScrollOptions {
+  duration?: number;
+  easeFunc?: SmoothScrollEaseFunc;
+}
+
+export interface SmoothScrollStep {
+  scrollable: HTMLElement;
+  startTime: number;
+  startX: number;
+  startY: number;
+  x: number;
+  y: number;
+  duration: number;
+  easeFunc: SmoothScrollEaseFunc;
+  currentX?: number;
+  currentY?: number;
+}
+
+// easing functions http://goo.gl/5HLl8
+export function easeInOutQuad(t: number, b: number, c: number, d: number): number {
+  t /= d / 2;
+  if (t < 1) {
+    return (c / 2) * t * t + b;
+  }
+  t--;
+  return (-c / 2) * (t * (t - 2) - 1) + b;
+}

--- a/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll.ts
+++ b/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll.ts
@@ -1,5 +1,6 @@
 import { Directive, ElementRef } from '@angular/core';
-import { SmoothScrollEaseFunc, SmoothScrollManager, SmoothScrollToOptions } from './smooth-scroll-manager';
+import { SmoothScrollManager } from './smooth-scroll-manager';
+import { SmoothScrollElement, SmoothScrollOptions, SmoothScrollToOptions } from './smooth-scroll.model';
 
 @Directive({
   selector: '[smoothScroll], [smooth-scroll]',
@@ -14,30 +15,23 @@ export class SmoothScroll {
     return this.smoothScroll.scrollTo(this.element, options);
   }
 
-  scrollToElement(target: HTMLElement | ElementRef<HTMLElement>,
-                  offset = 0,
-                  duration?: number,
-                  easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToElement(this.element, target, offset, duration, easeFunc);
+  scrollToElement(target: SmoothScrollElement, options: SmoothScrollOptions): Promise<void> {
+    return this.smoothScroll.scrollToElement(this.element, target, options);
   }
 
-  scrollToSelector(selector: string, offset = 0, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToSelector(this.element, selector, offset, duration, easeFunc);
+  scrollToTop(options): Promise<void> {
+    return this.smoothScroll.scrollToTop(this.element, options);
   }
 
-  scrollToTop(offset = 0, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToTop(this.element, offset, duration, easeFunc);
+  scrollToBottom(options): Promise<void> {
+    return this.smoothScroll.scrollToBottom(this.element, options);
   }
 
-  scrollToBottom(offset = 0, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToBottom(this.element, offset, duration, easeFunc);
+  scrollToRight(options): Promise<void> {
+    return this.smoothScroll.scrollToRight(this.element, options);
   }
 
-  scrollToRight(offset = 0, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToRight(this.element, offset, duration, easeFunc);
-  }
-
-  scrollToLeft(offset = 0, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToLeft(this.element, offset, duration, easeFunc);
+  scrollToLeft(options): Promise<void> {
+    return this.smoothScroll.scrollToLeft(this.element, options);
   }
 }

--- a/projects/ngx-scrollbar/src/lib/classes/horizontal-scrollbar-ref.ts
+++ b/projects/ngx-scrollbar/src/lib/classes/horizontal-scrollbar-ref.ts
@@ -54,42 +54,49 @@ export class HorizontalScrollbarRef extends ScrollbarRef {
     super(scrollbarRef, document, trackRef, thumbRef, platform, destroyed);
   }
 
+  private _handleThumbPosition(position: number, trackMax: number) {
+    if (this.dir.value === 'rtl') {
+      if (this.scrollbarRef.manager.rtlScrollAxisType === RtlScrollAxisType.INVERTED) {
+        return -position;
+      }
+      if (this.scrollbarRef.manager.rtlScrollAxisType === RtlScrollAxisType.NORMAL) {
+        return position - trackMax;
+      }
+      // Keeping this as a memo
+      // if (this.rtlScrollAxisType === RtlScrollAxisType.NEGATED) {
+      //   return position;
+      // }
+    }
+    return position;
+  }
+
+  protected handleDragPosition(position: number): number {
+    if (this.dir.value === 'rtl') {
+      if (this.scrollbarRef.manager.rtlScrollAxisType === RtlScrollAxisType.NEGATED) {
+        return position - this.scrollMax;
+      }
+      if (this.scrollbarRef.manager.rtlScrollAxisType === RtlScrollAxisType.INVERTED) {
+        return this.scrollMax - position;
+      }
+      // Keeping this as a memo
+      // if (this.rtlScrollAxisType === RtlScrollAxisType.NORMAL) {
+      //   return position;
+      // }
+    }
+    return position;
+  }
+
   protected scrolled(): Observable<any> {
     return this.scrollbarRef.horizontalScrolled;
   }
 
   protected applyThumbStyle(size: number, position: number, trackMax?: number): void {
     this.thumbElement.style.width = `${ size }px`;
-    let value = 0;
-    if (this.dir.value === 'rtl') {
-      if (getRtlScrollAxisType() === RtlScrollAxisType.NEGATED) {
-        value = position;
-      } else if (getRtlScrollAxisType() === RtlScrollAxisType.INVERTED) {
-        value = -position;
-      } else {
-        value = position - trackMax;
-      }
-    } else {
-      value = position;
-    }
-    this.thumbElement.style.transform = `translate3d(${ value }px, 0, 0)`;
+    this.thumbElement.style.transform = `translate3d(${ this._handleThumbPosition(position, trackMax) }px, 0, 0)`;
   }
 
   protected mapToScrollToOption(value: number): ScrollToOptions {
     return { left: value };
-  }
-
-  protected handleDragBrowserCompatibility(position: number): number {
-    if (this.dir.value === 'rtl') {
-      if (getRtlScrollAxisType() === RtlScrollAxisType.NEGATED) {
-        return position - this.scrollMax;
-      }
-      if (getRtlScrollAxisType() === RtlScrollAxisType.INVERTED) {
-        return this.scrollMax - position;
-      }
-      return position;
-    }
-    return position;
   }
 
   protected scrollTo(point: number): void {

--- a/projects/ngx-scrollbar/src/lib/classes/scrollbar-ref.ts
+++ b/projects/ngx-scrollbar/src/lib/classes/scrollbar-ref.ts
@@ -168,7 +168,7 @@ export abstract class ScrollbarRef {
         // Calculate how far the user's mouse is from the top/left of the scrollbar (minus the dragOffset).
         map((mouseOffset: number) => mouseOffset - this.dragOffset),
         map((offset: number) => scrollMax * (offset - mouseDownOffset) / trackMax),
-        map((position: number) => this.handleDragBrowserCompatibility(position, scrollMax)),
+        map((position: number) => this.handleDragPosition(position, scrollMax)),
         tap((value: number) => this.scrollTo(value)),
         takeUntil(dragEnd)
       ))
@@ -194,12 +194,11 @@ export abstract class ScrollbarRef {
     return of(e).pipe(
       pluck(this.pageProperty),
       map((pageOffset: number) => pageOffset - this.dragOffset),
-      map((clickOffset) => {
+      map((clickOffset: number) => {
         const offset = clickOffset - (this.thumbSize / 2);
         const ratio = offset / this.trackSize;
         return ratio * this.scrollSize;
       }),
-      map((position: number) => this.handleDragBrowserCompatibility(position, this.scrollMax)),
       tap((value: number) =>
         this.scrollbarRef.scrollTo({
           ...this.mapToScrollToOption(value),
@@ -228,7 +227,7 @@ export abstract class ScrollbarRef {
   /**
    * On drag function
    */
-  protected abstract handleDragBrowserCompatibility(position: number, scrollMax: number): number;
+  protected abstract handleDragPosition(position: number, scrollMax: number): number;
 
   protected abstract scrollTo(point: number): void;
 

--- a/projects/ngx-scrollbar/src/lib/classes/vertical-scrollbar-ref.ts
+++ b/projects/ngx-scrollbar/src/lib/classes/vertical-scrollbar-ref.ts
@@ -65,7 +65,7 @@ export class VerticalScrollbarRef extends ScrollbarRef {
     return { top: value };
   }
 
-  protected handleDragBrowserCompatibility(position: number): number {
+  protected handleDragPosition(position: number): number {
     return position;
   }
 

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar.ts
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar.ts
@@ -17,9 +17,9 @@ import { Directionality } from '@angular/cdk/bidi';
 import { fromEvent, Observable, Observer, Subject } from 'rxjs';
 import { filter, map, pairwise, pluck, takeUntil, tap } from 'rxjs/operators';
 import { ScrollViewport } from './scroll-viewport';
-import { SmoothScrollEaseFunc, SmoothScrollManager, SmoothScrollToOptions } from 'ngx-scrollbar/smooth-scroll';
+import { SmoothScrollElement, SmoothScrollManager, SmoothScrollToOptions } from 'ngx-scrollbar/smooth-scroll';
 // Uncomment the following line in development mode
-// import { SmoothScrollEaseFunc, SmoothScrollManager, SmoothScrollToOptions } from '../../smooth-scroll/src/public_api';
+// import { SmoothScrollElement, SmoothScrollManager, SmoothScrollToOptions } from '../../smooth-scroll/src/public_api';
 import { ScrollbarAppearance, ScrollbarTrack, ScrollbarPosition, ScrollbarVisibility, NgScrollbarState } from './ng-scrollbar.model';
 import { ScrollbarManager } from './utils/scrollbar-manager';
 import { NativeScrollbarSizeFactory } from './utils/native-scrollbar-size-factory';
@@ -243,28 +243,43 @@ export class NgScrollbar implements OnInit, AfterViewChecked, OnDestroy {
     return this.smoothScroll.scrollTo(this.viewport, options);
   }
 
-  scrollToElement(target: HTMLElement, offset = 0, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToElement(this.viewport, target, offset, duration, easeFunc);
+  /**
+   * Scroll to element by reference or selector
+   */
+  scrollToElement(target: SmoothScrollElement, options?): Promise<void> {
+    return this.smoothScroll.scrollToElement(this.viewport, target, options);
   }
 
-  scrollToSelector(selector: string, offset = 0, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToSelector(this.viewport, selector, offset, duration, easeFunc);
+  /**
+   * Scroll to top
+   * @deprecated since version 6.0, use scrollTo({ top: 0}) instead
+   */
+  scrollToTop(options?): Promise<void> {
+    return this.smoothScroll.scrollToTop(this.viewport, options);
   }
 
-  scrollToTop(offset?: number, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToTop(this.viewport, offset, duration, easeFunc);
+  /**
+   * Scroll to bottom
+   * @deprecated since version 6.0, use scrollTo({ bottom: 0}) instead
+   */
+  scrollToBottom(options?): Promise<void> {
+    return this.smoothScroll.scrollToBottom(this.viewport, options);
   }
 
-  scrollToBottom(offset?: number, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToBottom(this.viewport, offset, duration, easeFunc);
+  /**
+   *  Scroll to left
+   * @deprecated since version 6.0, use scrollTo({ left: 0}) instead
+   */
+  scrollToLeft(options?): Promise<void> {
+    return this.smoothScroll.scrollToLeft(this.viewport, options);
   }
 
-  scrollToRight(offset?: number, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToRight(this.viewport, offset, duration, easeFunc);
-  }
-
-  scrollToLeft(offset?: number, duration?: number, easeFunc?: SmoothScrollEaseFunc): Promise<void> {
-    return this.smoothScroll.scrollToLeft(this.viewport, offset, duration, easeFunc);
+  /**
+   * Scroll to right
+   * @deprecated since version 6.0, use scrollTo({ right: 0}) instead
+   */
+  scrollToRight(options?): Promise<void> {
+    return this.smoothScroll.scrollToRight(this.viewport, options);
   }
 }
 


### PR DESCRIPTION
- Add the ability to pass `HTMLElement`, `ElementRef` or `string` for element selector in the smooth scroll functions.
- Add the ability to use scrollTo functions using `top`, `left`, `right`, `bottom`, `start` and `end`.
- Add the ability to set offset in `scrollToElement` functions using `top`, `left`.
- Fix all smooth scroll glitches