### PR TITLE
Added check for undefined size within the CssVariable pipe

### DIFF
--- a/projects/ngx-scrollbar/src/lib/utils/css-variable.pipe.ts
+++ b/projects/ngx-scrollbar/src/lib/utils/css-variable.pipe.ts
@@ -6,7 +6,11 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 })
 export class CssVariable implements PipeTransform {
 
-  transform(size: number, variableName): SafeHtml {
+  transform(size: number | undefined, variableName): SafeHtml {
+    if (size === undefined) {
+      size = 0;
+    }
+
     return this.sanitizer.bypassSecurityTrustStyle(`--${variableName}: -${size}px`);
   }
 


### PR DESCRIPTION
Added check for undefined size within the CssVariable pipe in order to fix production builds when strictNullChecks is set to true

This is a fix for: https://github.com/MurhafSousli/ngx-scrollbar/issues/219