### PR TITLE
Add repository field into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "link-lib": "npm link dist/ngx-scrollbar && npm link ngx-scrollbar",
     "publish-lib": "npm publish dist/ngx-scrollbar"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MurhafSousli/ngx-scrollbar"
+  },
   "dependencies": {
     "@angular/animations": "~8.2.3",
     "@angular/cdk": "~8.1.3",


### PR DESCRIPTION
Without that field you have no link to github from npmjs and you can not use `npm repo `ngx-scrollbar`.