### PR TITLE
fix: scrollToElement customOptions default value

### DIFF
--- a/projects/ngx-scrollbar-demo/src/app/app.component.html
+++ b/projects/ngx-scrollbar-demo/src/app/app.component.html
@@ -19,6 +19,8 @@
 
       <app-example2></app-example2>
 
+      <app-example-scrollto-element></app-example-scrollto-element>
+
       <app-example3></app-example3>
 
       <app-example4></app-example4>

--- a/projects/ngx-scrollbar-demo/src/app/app.module.ts
+++ b/projects/ngx-scrollbar-demo/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { ToggleFormComponent } from './example-x/toggle-form/toggle-form.compone
 import { ReachedNotifierComponent } from './example-x/reached-notifier/reached-notifier.component';
 import { SmoothScrollFormComponent } from './example-x/smooth-scroll-form/smooth-scroll-form.component';
 import { SponsorsComponent } from './sponsors/sponsors.component';
+import { ExampleScrolltoElementComponent } from './example-scrollto-element/example-scrollto-element.component';
 
 @NgModule({
   declarations: [
@@ -37,6 +38,7 @@ import { SponsorsComponent } from './sponsors/sponsors.component';
     ExampleVirtualScrollComponent,
     ExampleInfiniteScrollComponent,
     ExampleNestedVirtualScrollComponent,
+    ExampleScrolltoElementComponent,
     CardComponent,
     ResizeFormComponent,
     ToggleFormComponent,

--- a/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.html
+++ b/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.html
@@ -7,14 +7,13 @@
   <mat-card-content>
     <div class="scrolltoExample">
     <ng-scrollbar appearance="compact">
-      <mat-list>
-        <mat-list-item class="example-item"
+      <ul>
+        <li class="example-item"
           *ngFor="let item of [].constructor(20); index as i"
-          #itemEl
-          (click)="scrollToItem(itemEl)">
+          (click)="scrollToItem(itemEl)" #itemEl>
           item {{i}}
-        </mat-list-item>
-      </mat-list>
+      </li>
+    </ul>
     </ng-scrollbar>
     </div>
   </mat-card-content>

--- a/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.html
+++ b/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.html
@@ -1,0 +1,21 @@
+<mat-card class="example">
+  <mat-card-header>
+    <mat-card-title>
+      ScrollToElement
+    </mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <div class="scrolltoExample">
+    <ng-scrollbar appearance="compact">
+      <mat-list>
+        <mat-list-item class="example-item"
+          *ngFor="let item of [].constructor(20); index as i"
+          #itemEl
+          (click)="scrollToItem(itemEl)">
+          item {{i}}
+        </mat-list-item>
+      </mat-list>
+    </ng-scrollbar>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.scss
+++ b/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.scss
@@ -7,7 +7,7 @@
   background-color: #f3f3f3;
   border-radius: 3px;
   overflow: hidden;
-  height: 200px;
+  height: 300px;
 
   .mat-list-base {
     padding-top: 0;
@@ -24,10 +24,12 @@
   }
 
   .example-item {
-
+    display: flex;
+    align-items: center;
     height: 50px;
     color: black;
     cursor: pointer;
+    padding: 0 15px;
 
     &:nth-child(odd) {
       background: #f1ffff;
@@ -39,7 +41,6 @@
 
     &:hover{
       background: #d2d2ff;
-      color: #fff;
     }
   }
 

--- a/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.scss
+++ b/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.scss
@@ -1,0 +1,46 @@
+.example {
+  background-color: var(--color-virtual-scroll-example);
+  color: white;
+}
+
+.scrolltoExample {
+  background-color: #f3f3f3;
+  border-radius: 3px;
+  overflow: hidden;
+  height: 200px;
+
+  .mat-list-base {
+    padding-top: 0;
+  }
+  ng-scrollbar {
+    --scrollbar-track-color: rgba(0, 0, 0, 0.05);
+    --scrollbar-thumb-color: var(--color-virtual-scroll-example);
+    //--scrollbar-size: 8px;
+    --scrollbar-size: 12px;
+    --scrollbar-padding: 6px;
+    --scrollbar-border-radius: 8px;
+    border-radius: 3px;
+    border: 2px solid rgba(0, 0, 0, 0.05);
+  }
+
+  .example-item {
+
+    height: 50px;
+    color: black;
+    cursor: pointer;
+
+    &:nth-child(odd) {
+      background: #f1ffff;
+    }
+
+    &:nth-child(even) {
+      background: #ecf8ff;
+    }
+
+    &:hover{
+      background: #d2d2ff;
+      color: #fff;
+    }
+  }
+
+}

--- a/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.ts
+++ b/projects/ngx-scrollbar-demo/src/app/example-scrollto-element/example-scrollto-element.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
+import { NgScrollbar } from 'ngx-scrollbar';
+
+@Component({
+  selector: 'app-example-scrollto-element',
+  templateUrl: './example-scrollto-element.component.html',
+  styleUrls: ['./example-scrollto-element.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class.example-component]': 'true'
+  }
+})
+export class ExampleScrolltoElementComponent {
+
+  @ViewChild(NgScrollbar, { static: true }) scrollbar: NgScrollbar;
+
+  scrollToItem(el: HTMLElement) {
+    this.scrollbar.scrollToElement(el);
+  }
+}

--- a/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll-manager.ts
+++ b/projects/ngx-scrollbar/smooth-scroll/src/smooth-scroll-manager.ts
@@ -225,7 +225,7 @@ export class SmoothScrollManager {
   /**
    * Scroll to element by reference or selector
    */
-  scrollToElement(scrollable: SmoothScrollElement, target: SmoothScrollElement, customOptions: SmoothScrollOptions & _Top & _Left): Promise<void> {
+  scrollToElement(scrollable: SmoothScrollElement, target: SmoothScrollElement, customOptions: SmoothScrollOptions & _Top & _Left = {}): Promise<void> {
     const scrollableEl = this._getElement(scrollable);
     const targetEl = this._getElement(target, scrollableEl);
     const options: SmoothScrollToOptions = {


### PR DESCRIPTION
In this usage:
```html
<ul>
        <li *ngFor="let item of [].constructor(20); index as i"
          #itemEl (click)="scrollToItem(itemEl)">
          item {{i}}
      </li>
    </ul>
```
```js
scrollToItem(el: HTMLElement) {
    this.scrollbar.scrollToElement(el);
  }
```
Getting error:
```
Cannot read property 'left' of undefined
    at SmoothScrollManager.scrollToElement (smooth-scroll-manager.ts:234)
```
Right now the workaround is to call `scrollToElement` with `{}` as a second parameter:
```js
    this.scrollable.scrollToElement(el, {});
```
see example here: https://stackblitz.com/edit/ngx-scrollbar-p3b299?file=src%2Fapp%2Fhome%2Fhome.component.ts

___
in `ng-scrollbar.ts` options variable is not required:
```js
scrollToElement(target: SmoothScrollElement, options?: any): Promise<void> {
    return this.smoothScroll.scrollToElement(this.viewport!.nativeElement, target, options);
  }
```
however in `smooth-scroll-manager.ts` customOptions doesn't have a default value and used this way too.
```js
scrollToElement(scrollable: SmoothScrollElement, target: SmoothScrollElement, customOptions: SmoothScrollOptions & _Top & _Left): Promise<void> {
    const scrollableEl = this._getElement(scrollable);
    const targetEl = this._getElement(target, scrollableEl);
    const options: SmoothScrollToOptions = {
      ...customOptions,
      ...{
        left: targetEl.offsetLeft + (customOptions.left || 0), // <-- customOptions is null or undefined
        top: targetEl.offsetTop + (customOptions.top || 0)
      }
    };
    return targetEl ? this.scrollTo(scrollableEl, options) : Promise.resolve();
  }
```

So this PR just adds default value `{}` to `customOptions`

I've added  a demo  `app/example-scrollto-element` in the demo app