### PR TITLE
fix: Make peerDependencies compatible with previous angular version

### DIFF
--- a/projects/ngx-scrollbar/package.json
+++ b/projects/ngx-scrollbar/package.json
@@ -24,9 +24,9 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^11.0.0",
-    "@angular/core": "^11.0.0",
-    "@angular/cdk": "^11.0.0",
-    "rxjs": "^6.0.0"
+    "@angular/common": ">=11.0.0",
+    "@angular/core": ">=11.0.0",
+    "@angular/cdk": ">=11.0.0",
+    "rxjs": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Closes #368