### PR TITLE
CDK virtual scroll documentation issue fix

### DIFF
--- a/README_V4.md
+++ b/README_V4.md
@@ -483,13 +483,13 @@ To use virtual scroll, you will need to add the `ngScrollbarView` directive alon
 
 ```html
 <ng-scrollbar>
-  <cdk-virtual-scroll-viewport ngScrollbarView smoothScroll itemSize="50">
+  <cdk-virtual-scroll-viewport scrollViewport itemSize="50">
     <div *cdkVirtualFor="let item of items">{{item}}</div>
   </cdk-virtual-scroll-viewport>
 </ng-scrollbar>
 ```
 
-Here is a [stackblitz example](https://ngx-scrollbar.stackblitz.io/#/lazy-test)
+Here is a [stackblitz example](https://stackblitz.com/edit/ngx-scrollbar) (checkout Virtual Scroll tab).
 
 <a name="development"/>
 


### PR DESCRIPTION
There's a discrepancy in the documentation sample of ng-scrollbar combined with cdk-virtual-scroll-viewport  and stackbiz sample. Because of misleading documentation I could not configure properly the ng-scrollbar to work with virtual scroll. Apart from that, the stackbiz link was leading to the production version without possibility to see the source code. Both of the problems are addressed in this proposed changes.