### PR TITLE
Fix npm install not woking on Angular 16 installation

### DIFF
--- a/projects/ngx-scrollbar/package.json
+++ b/projects/ngx-scrollbar/package.json
@@ -23,9 +23,9 @@
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "@angular/common": ">=16.0.0",
-    "@angular/core": ">=16.0.0",
-    "@angular/cdk": ">=16.0.0",
+    "@angular/common": "^16.0.0",
+    "@angular/core": "^16.0.0",
+    "@angular/cdk": "^16.0.0",
     "rxjs": ">=7.0.0"
   }
 }


### PR DESCRIPTION
```ngx-scrollbar``` peer dependency to ```@angular/cdk``` is not working. It tries to resolve for ```@angular/cdk``` v.17. Which then causes errors when the consuming app is on Angular 16.

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: b2b-advisor-web@1.19.0
npm ERR! Found: @angular/common@16.2.12
npm ERR! node_modules/@angular/common
npm ERR!   @angular/common@"^16.2.12" from the root project
npm ERR!   peer @angular/common@">=16.0.0" from ngx-scrollbar@13.0.3
npm ERR!   node_modules/ngx-scrollbar
npm ERR!     ngx-scrollbar@"13.0.3" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @angular/common@"^17.0.0 || ^18.0.0" from @angular/cdk@17.0.0
npm ERR! node_modules/@angular/cdk
npm ERR!   peer @angular/cdk@">=16.0.0" from ngx-scrollbar@13.0.3
npm ERR!   node_modules/ngx-scrollbar
npm ERR!     ngx-scrollbar@"13.0.3" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
```

Using an override in package.json works:
```
 "overrides": {
    "ngx-scrollbar": {
      "@angular/cdk":"^16.2.12"
    }
  },
```
Please take a look @MurhafSousli