### PR TITLE
v15.0.1

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Build
         run: npm run build-lib

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 20
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
       - name: Build demo
         run: npm run build
       - name: Deploy to Netlify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 15.0.1
+
+- fix: SSR with CDK Virtual Scroll - `ResizeObserver` is not defined error thrown, closes [#603](https://github.com/MurhafSousli/ngx-scrollbar/issues/603).
+- regret: Remove the `requestAnimationFrame` before emitting to `afterInit` and `afterUpdate` which was added to fix the unit tests.
+
+ > This was not a bug or an issue in the previous version v15.0.0
+
 ## 15.0.0
 
 - feat: Upgrade to Angular 18.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "ag-grid-community": "^31.3.2",
         "chance": "^1.1.11",
         "express": "^4.18.2",
-        "ng-zorro-antd": "^17.4.1",
+        "ng-zorro-antd": "^18.0.0-beta.0",
         "ngx-color-picker": "^16.0.0",
         "ngx-infinite-scroll": "^18.0.0",
         "primeng": "^17.18.0",
@@ -951,6 +951,21 @@
       "integrity": "sha512-7KJkhTiPiLHSu+LmMJnehfJ6242OCxSlR3xHVBecYxnMW8MS/878NXct1GqYARyL59fyeFdKRxXTfvR9SnDgJg==",
       "dependencies": {
         "@ctrl/tinycolor": "^3.6.1"
+      }
+    },
+    "node_modules/@ant-design/icons-angular": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-angular/-/icons-angular-18.0.0.tgz",
+      "integrity": "sha512-nxNtHKd7MyGNnEyv22NK5hZ/Pczp63XJfej9zPjxiXm0wvJeIdMNUPOKtsdVkyPTRjRGHGe7F9M0Gv9SmyIjrQ==",
+      "dependencies": {
+        "@ant-design/colors": "^7.0.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^18.0.0",
+        "@angular/core": "^18.0.0",
+        "@angular/platform-browser": "^18.0.0",
+        "rxjs": "^6.4.0 || ^7.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -11983,53 +11998,22 @@
       }
     },
     "node_modules/ng-zorro-antd": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/ng-zorro-antd/-/ng-zorro-antd-17.4.1.tgz",
-      "integrity": "sha512-KsMYFlRBFPK5FPPoaYIS/uzQ4400WFMLcA9/1LmYZcSgmeINlCvgfiitNcOVLsRyQYlpdIQyOo9z5Ue2SS9ypg==",
+      "version": "18.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/ng-zorro-antd/-/ng-zorro-antd-18.0.0-beta.0.tgz",
+      "integrity": "sha512-Zd0QBr5isBE6JPFrDzDPuPYhbrqUoXtk0bQKed+Lg9yupOEm47ETnIIfI2dftbpqhNrOYE1cYww4STAQlLxS8g==",
       "dependencies": {
-        "@angular/cdk": "^17.0.0",
-        "@ant-design/icons-angular": "^17.0.0",
+        "@angular/cdk": "^18.0.0",
+        "@ant-design/icons-angular": "^18.0.0",
         "date-fns": "^2.16.1",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/animations": "^17.0.0",
-        "@angular/common": "^17.0.0",
-        "@angular/core": "^17.0.0",
-        "@angular/forms": "^17.0.0",
-        "@angular/platform-browser": "^17.0.0",
-        "@angular/router": "^17.0.0"
-      }
-    },
-    "node_modules/ng-zorro-antd/node_modules/@angular/cdk": {
-      "version": "17.3.10",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.3.10.tgz",
-      "integrity": "sha512-b1qktT2c1TTTe5nTji/kFAVW92fULK0YhYAvJ+BjZTPKu2FniZNe8o4qqQ0pUuvtMu+ZQxp/QqFYoidIVCjScg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "optionalDependencies": {
-        "parse5": "^7.1.2"
-      },
-      "peerDependencies": {
-        "@angular/common": "^17.0.0 || ^18.0.0",
-        "@angular/core": "^17.0.0 || ^18.0.0",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "node_modules/ng-zorro-antd/node_modules/@ant-design/icons-angular": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-angular/-/icons-angular-17.0.0.tgz",
-      "integrity": "sha512-MNEh3UbkSl6gkdb5MQRNHEuWI1DnU1dME9zSymnWCipEXN7MB0mcYHSfyYTqKL1j45ftp6l1UnsLvhokRYyhXA==",
-      "dependencies": {
-        "@ant-design/colors": "^7.0.0",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^17.0.1",
-        "@angular/core": "^17.0.1",
-        "@angular/platform-browser": "^17.0.1",
-        "rxjs": "^6.4.0 || ^7.4.0"
+        "@angular/animations": "^18.0.0",
+        "@angular/common": "^18.0.0",
+        "@angular/core": "^18.0.0",
+        "@angular/forms": "^18.0.0",
+        "@angular/platform-browser": "^18.0.0",
+        "@angular/router": "^18.0.0"
       }
     },
     "node_modules/ngx-color-picker": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ag-grid-community": "^31.3.2",
     "chance": "^1.1.11",
     "express": "^4.18.2",
-    "ng-zorro-antd": "^17.4.1",
+    "ng-zorro-antd": "^18.0.0-beta.0",
     "ngx-color-picker": "^16.0.0",
     "ngx-infinite-scroll": "^18.0.0",
     "primeng": "^17.18.0",

--- a/projects/ngx-scrollbar/cdk/src/cdk-virtual-scroll.ts
+++ b/projects/ngx-scrollbar/cdk/src/cdk-virtual-scroll.ts
@@ -7,6 +7,7 @@ import {
   Signal,
   EffectCleanupRegisterFn
 } from '@angular/core';
+import { Platform } from '@angular/cdk/platform';
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { NgScrollbarExt } from 'ngx-scrollbar';
 
@@ -17,6 +18,8 @@ import { NgScrollbarExt } from 'ngx-scrollbar';
 export class NgScrollbarCdkVirtualScroll {
 
   private readonly scrollbar: NgScrollbarExt = inject(NgScrollbarExt);
+
+  private readonly platform: Platform = inject(Platform);
 
   private readonly virtualScrollViewportRef: Signal<CdkVirtualScrollViewport> = contentChild(CdkVirtualScrollViewport);
 
@@ -34,7 +37,7 @@ export class NgScrollbarCdkVirtualScroll {
 
       const spacer: HTMLElement = virtualScrollViewport.elementRef.nativeElement.querySelector(this.scrollbar.externalSpacer);
 
-      if (virtualScrollViewport) {
+      if (this.platform.isBrowser && virtualScrollViewport) {
         resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
           entries.forEach((entry: ResizeObserverEntry) => {
             if (virtualScrollViewport.orientation === 'vertical') {
@@ -53,7 +56,7 @@ export class NgScrollbarCdkVirtualScroll {
         });
       }
 
-      onCleanup(() => resizeObserver.disconnect());
+      onCleanup(() => resizeObserver?.disconnect());
     });
   }
 }

--- a/projects/ngx-scrollbar/package.json
+++ b/projects/ngx-scrollbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-scrollbar",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "license": "MIT",
   "homepage": "https://ngx-scrollbar.netlify.com/",
   "author": {

--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar-core.ts
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar-core.ts
@@ -295,13 +295,11 @@ export abstract class NgScrollbarCore implements _NgScrollbar, OnInit, AfterView
 
       // After the upgrade to Angular 18, the effect functions in the inner directives are executed after "afterInit" is emitted,
       // causing the tests to fail. A tiny delay is needed before emitting to the output as a workaround.
-      requestAnimationFrame(() => {
-        if (reason === ScrollbarUpdateReason.AfterInit) {
-          this.afterInit.emit();
-        } else {
-          this.afterUpdate.emit();
-        }
-      });
+      if (reason === ScrollbarUpdateReason.AfterInit) {
+        this.afterInit.emit();
+      } else {
+        this.afterUpdate.emit();
+      }
     });
   }
 

--- a/projects/ngx-scrollbar/src/lib/tests/button.spec.ts
+++ b/projects/ngx-scrollbar/src/lib/tests/button.spec.ts
@@ -68,6 +68,7 @@ describe('Buttons', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const button: DebugElement = fixture.debugElement.query(By.css('button[scrollbarButton="bottom"]'));
     button.nativeElement.dispatchEvent(new PointerEvent('pointerdown'));
@@ -99,6 +100,7 @@ describe('Buttons', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     await component.scrollTo({ bottom: 0, duration: 0 });
 
@@ -131,6 +133,7 @@ describe('Buttons', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const button: DebugElement = fixture.debugElement.query(By.css('button[scrollbarButton="end"]'));
     button.nativeElement.dispatchEvent(new PointerEvent('pointerdown'));
@@ -162,6 +165,7 @@ describe('Buttons', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     await component.scrollTo({ end: 0, duration: 0 });
 
@@ -196,6 +200,7 @@ describe('Buttons', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const button: DebugElement = fixture.debugElement.query(By.css('button[scrollbarButton="end"]'));
     button.nativeElement.dispatchEvent(new PointerEvent('pointerdown'));
@@ -227,6 +232,7 @@ describe('Buttons', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     await component.scrollTo({ end: 0, duration: 0 });
 
@@ -260,6 +266,7 @@ describe('Buttons', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const button: DebugElement = fixture.debugElement.query(By.css('button[scrollbarButton="bottom"]'));
     button.nativeElement.dispatchEvent(new PointerEvent('pointerdown'));
@@ -279,6 +286,7 @@ describe('Buttons', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const button: DebugElement = fixture.debugElement.query(By.css('button[scrollbarButton="bottom"]'));
     button.nativeElement.dispatchEvent(new PointerEvent('pointerdown'));

--- a/projects/ngx-scrollbar/src/lib/tests/disable-interactions.spec.ts
+++ b/projects/ngx-scrollbar/src/lib/tests/disable-interactions.spec.ts
@@ -97,6 +97,7 @@ describe('disableInteraction option', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     trackY = fixture.debugElement.query(By.css('scrollbar-y .ng-scrollbar-track')).injector.get(TrackAdapter);
     thumbY = fixture.debugElement.query(By.css('scrollbar-y .ng-scrollbar-thumb')).injector.get(ThumbAdapter);

--- a/projects/ngx-scrollbar/src/lib/tests/ng-scrollbar.spec.ts
+++ b/projects/ngx-scrollbar/src/lib/tests/ng-scrollbar.spec.ts
@@ -3,7 +3,7 @@ import { DebugElement } from '@angular/core';
 import { NgScrollbar } from 'ngx-scrollbar';
 import { By } from '@angular/platform-browser';
 import { firstValueFrom } from 'rxjs';
-import { afterTimeout, setDimensions } from './common-test.';
+import { setDimensions } from './common-test.';
 
 describe('NgScrollbar Component', () => {
   let component: NgScrollbar;
@@ -35,7 +35,6 @@ describe('NgScrollbar Component', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     component.update();
-    await afterTimeout(16);
     expect(afterUpdateEmitSpy).toHaveBeenCalled();
   });
 

--- a/projects/ngx-scrollbar/src/lib/tests/resize-sensor.spec.ts
+++ b/projects/ngx-scrollbar/src/lib/tests/resize-sensor.spec.ts
@@ -48,7 +48,7 @@ describe('Resize Sensor', () => {
     // Change component size
     setDimensions(component, { cmpHeight: 200, cmpWidth: 200, contentHeight: 400, contentWidth: 400 });
 
-    await firstValueFrom(component.afterUpdate)
+    await firstValueFrom(component.afterUpdate);
 
     expect(component.viewportDimension()).toEqual({
       offsetWidth: 200,

--- a/projects/ngx-scrollbar/src/lib/tests/thumb.spec.ts
+++ b/projects/ngx-scrollbar/src/lib/tests/thumb.spec.ts
@@ -46,6 +46,7 @@ describe('Scrollbar thumb', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const thumbY: Element = fixture.debugElement.query(By.css('scrollbar-y .ng-scrollbar-thumb')).nativeElement;
     thumbY.dispatchEvent(new PointerEvent('pointerdown'));
@@ -75,6 +76,7 @@ describe('Scrollbar thumb', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const thumbX: Element = fixture.debugElement.query(By.css('scrollbar-x .ng-scrollbar-thumb')).nativeElement;
     thumbX.dispatchEvent(new PointerEvent('pointerdown'));
@@ -105,6 +107,7 @@ describe('Scrollbar thumb', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const thumbX: Element = fixture.debugElement.query(By.css('scrollbar-x .ng-scrollbar-thumb')).nativeElement;
     thumbX.dispatchEvent(new PointerEvent('pointerdown'));
@@ -134,6 +137,7 @@ describe('Scrollbar thumb', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const thumbAdapter: ThumbAdapter = fixture.debugElement.query(By.css('scrollbar-x .ng-scrollbar-thumb')).injector.get(ThumbAdapter);
     expect(thumbAdapter._animation).toBeTruthy();

--- a/projects/ngx-scrollbar/src/lib/tests/track.spec.ts
+++ b/projects/ngx-scrollbar/src/lib/tests/track.spec.ts
@@ -48,6 +48,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const trackYDebugElement: DebugElement = fixture.debugElement.query(By.directive(TrackYDirective));
     const thumbYDebugElement: DebugElement = fixture.debugElement.query(By.directive(ThumbYDirective));
@@ -78,6 +79,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     await component.scrollTo({ bottom: 0, duration: 0 });
 
@@ -112,6 +114,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const trackYDebugElement: DebugElement = fixture.debugElement.query(By.directive(TrackYDirective));
     const thumbYDebugElement: DebugElement = fixture.debugElement.query(By.directive(ThumbYDirective));
@@ -144,6 +147,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     await component.scrollTo({ bottom: 0, duration: 0 });
 
@@ -176,6 +180,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const trackXDebugElement: DebugElement = fixture.debugElement.query(By.directive(TrackXDirective));
     const thumbXDebugElement: DebugElement = fixture.debugElement.query(By.directive(ThumbXDirective));
@@ -206,6 +211,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     await component.scrollTo({ end: 0, duration: 0 });
 
@@ -239,6 +245,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     await component.scrollTo({ start: 0, duration: 0 });
 
@@ -272,6 +279,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     await component.scrollTo({ end: 0, duration: 0 });
 
@@ -304,6 +312,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     // Make current scroll position close to bottom, so it triggers only one scroll to the end
     await component.scrollTo({ bottom: 90, duration: 50 });
@@ -328,6 +337,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     // Make current scroll position close to top, so it triggers only one scroll step to finish
     await component.scrollTo({ top: 50, duration: 0 });
@@ -351,6 +361,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const trackYDebugElement: DebugElement = fixture.debugElement.query(By.directive(TrackYDirective));
 
@@ -394,6 +405,7 @@ describe('Scrollbar track', () => {
     component.ngOnInit();
     component.ngAfterViewInit();
     await firstValueFrom(component.afterInit);
+    TestBed.flushEffects();
 
     const trackYDebugElement: DebugElement = fixture.debugElement.query(By.directive(TrackYDirective));
     const thumbYDebugElement: DebugElement = fixture.debugElement.query(By.directive(ThumbYDirective));


### PR DESCRIPTION
- regret: fix unit test and remove `requestAnimationFrame` before emitting to the `afterInit` and `afterUpdate` outputs which was added as workaround to fix the unit test in v15.0.0.