### PR TITLE
fix: prevent error "ResizeObserver loop completed with undelivered notifications"

### DIFF
--- a/projects/ngx-scrollbar/src/lib/tests/resize-sensor.spec.ts
+++ b/projects/ngx-scrollbar/src/lib/tests/resize-sensor.spec.ts
@@ -91,7 +91,7 @@ describe('Resize Sensor', () => {
     // Change content size
     setDimensions(component, { cmpHeight: 100, cmpWidth: 100, contentHeight: 500, contentWidth: 500 });
 
-    // Wait for 200ms
+    // Wait for 100ms
     await afterTimeout(100);
 
     // Verify viewport dimension haven't been updated
@@ -102,8 +102,8 @@ describe('Resize Sensor', () => {
       contentHeight: 400
     });
 
-    // Wait for another 200ms
-    await afterTimeout(100);
+    // Wait for another 100ms (actually wait a little longer to account for requestAnimationFrame):
+    await afterTimeout(105);
 
     // Verify that viewport been updated
     expect(component.viewportDimension()).toEqual({

--- a/projects/ngx-scrollbar/src/lib/viewport/observer.ts
+++ b/projects/ngx-scrollbar/src/lib/viewport/observer.ts
@@ -16,9 +16,11 @@ export function resizeObserver({ element, contentWrapper, throttleDuration }: Re
 
   const stream: Observable<ScrollbarUpdateReason> = new Observable((observer: Observer<ScrollbarUpdateReason>) => {
     resizeObserver = new ResizeObserver(() => {
-      observer.next(reason);
-      // After first init event, mark the reason to be a resize from now on.
-      reason = ScrollbarUpdateReason.Resized;
+      requestAnimationFrame(() => {
+        observer.next(reason);
+        // After first init event, mark the reason to be a resize from now on.
+        reason = ScrollbarUpdateReason.Resized;
+      });
     });
     resizeObserver.observe(element);
 


### PR DESCRIPTION
see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors 
fixes #650