### PR TITLE
Update ng-scrollbar-core.ts

### DIFF
--- a/projects/ngx-scrollbar/src/lib/ng-scrollbar-core.ts
+++ b/projects/ngx-scrollbar/src/lib/ng-scrollbar-core.ts
@@ -121,7 +121,7 @@ export abstract class NgScrollbarCore implements _NgScrollbar {
    *
    * - `native` (default) Scrollbar will be visible when viewport is scrollable like with native scrollbar
    * - `hover` Scrollbars are hidden by default, only visible on scrolling or hovering
-   * - `always` Scrollbars are always shown even if the viewport is not scrollable
+   * - `visible` Scrollbars are always shown even if the viewport is not scrollable
    */
   visibility: InputSignal<ScrollbarVisibility> = input<ScrollbarVisibility>(this.options.visibility);
 


### PR DESCRIPTION
updated comment to use correct attribute. 

fixed to the correct attribute in commented docs, so that when you hover over the element in VS Code, it gives you correct attributes. 
<img width="996" height="221" alt="image" src="https://github.com/user-attachments/assets/fbc733a9-158f-4c91-b6cb-4bf472c91f7c" />
