### PR TITLE
feat(scrollbar): expose z-index as a CSS variable / SCSS config

### DIFF
--- a/projects/ngx-scrollbar/_index.scss
+++ b/projects/ngx-scrollbar/_index.scss
@@ -16,6 +16,11 @@
       map.get($config, container-shape),
       inherit
   );
+  $z-index: if(
+      map.has-key($config, z-index),
+      map.get($config, z-index),
+      inherit
+  );
 
   $track-shape: if(
       map.has-key($config, track-shape),
@@ -175,6 +180,10 @@
 
   @if $container-shape {
     --scrollbar-container-shape: #{$container-shape};
+  }
+
+  @if $z-index {
+    --scrollbar-z-index: #{$z-index};
   }
 
   @if $track-shape {

--- a/projects/ngx-scrollbar/docs/Styling.md
+++ b/projects/ngx-scrollbar/docs/Styling.md
@@ -24,6 +24,7 @@ The recommended way to apply these overrides globally is by using the @include s
 | `container-color`                         |                   | Set the scrollbar container color                        |
 | `container-offset`                        | 0px               | Set the gutter between the outer container and the edge  |
 | `container-shape`                         | 0px               | Set the border radius of the scrollbar track container   |
+| `z-index`                                 | 200               | Stacking order of the scrollbar host (raised above @angular/cdk sticky table cells, which can reach 102) |
 | `track-shape`                             | 10px              | Adjust the border radius of the scrollbar track          |
 | `track-thickness`                         | 7px               | Track thickness                                          |
 | `track-hover-thickness`                   |                   | Track hover thickness                                    |

--- a/projects/ngx-scrollbar/src/lib/scrollbar/shared.scss
+++ b/projects/ngx-scrollbar/src/lib/scrollbar/shared.scss
@@ -3,7 +3,11 @@
   height: var(--_scrollbar-wrapper-height);
   width: var(--_scrollbar-wrapper-width);
   position: sticky;
-  z-index: 100;
+  // Default raised above @angular/cdk's StickyStyler max combo (footer 10 + start/end 1 + 1 = 12,
+  // header 100 + start/end 1 + 1 = 102) so the scrollbar always sits above sticky table cells.
+  // Override via the SCSS `z-index` config key or directly with the `--scrollbar-z-index` custom
+  // property when host content uses higher z-indexes.
+  z-index: var(--scrollbar-z-index, 200);
   opacity: var(--_scrollbar-hover-opacity);
   transition: var(--_scrollbar-opacity-transition);
   background: var(--scrollbar-container-color, transparent);


### PR DESCRIPTION
The scrollbar host had a hardcoded `z-index: 100`, which collides with `@angular/cdk/table`'s `StickyStyler`. CDK sums sticky-direction z-index increments (top=100, bottom=10, left=1, right=1), so any header cell that's also part of a stickyStart/stickyEnd column lands at 101 and covers the scrollbar.

This wires the host z-index through a new `--scrollbar-z-index` custom property (also exposed as a `z-index` key in the existing `ng-scrollbar-overrides` SCSS mixin), defaulted to 200 so the scrollbar sits above the highest reachable CDK sticky combo (top + left + right = 102) out of the box. Consumers whose layout uses higher z-indexes can override via the config or the CSS variable.

Fixes #729